### PR TITLE
fix: make `<=11` work the same as in npm

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -10,7 +10,7 @@ use nom::multi::{many_till, separated_list0};
 use nom::sequence::{delimited, preceded, terminated, tuple};
 use nom::{Err, IResult};
 
-use crate::{extras, number, Identifier, SemverError, SemverErrorKind, SemverParseError, Version};
+use crate::{extras, number, Identifier, SemverError, SemverErrorKind, SemverParseError, Version, MAX_SAFE_INTEGER};
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct BoundSet {
@@ -637,12 +637,23 @@ fn primitive(input: &str) -> IResult<&str, Option<BoundSet>, SemverParseError<&s
                     LessThanEquals,
                     Partial {
                         major,
+                        minor: None,
+                        patch: None,
+                        ..
+                    },
+                ) => BoundSet::at_most(Predicate::Including(
+                    (major.unwrap_or(0), MAX_SAFE_INTEGER, MAX_SAFE_INTEGER).into(),
+                )),
+                (
+                    LessThanEquals,
+                    Partial {
+                        major,
                         minor,
                         patch: None,
                         ..
                     },
                 ) => BoundSet::at_most(Predicate::Including(
-                    (major.unwrap_or(0), minor.unwrap_or(0), 0, 0).into(),
+                    (major.unwrap_or(0), minor.unwrap_or(0), MAX_SAFE_INTEGER).into(),
                 )),
                 (LessThanEquals, partial) => {
                     BoundSet::at_most(Predicate::Including(partial.into()))


### PR DESCRIPTION
The current version of `<=` in this crate does not fully match npm.

For example, `<=11` currently is equivalent to `<=11.0.0-0` however in npm `<=11` is equivalent to `<12` (or `<=11.MAX_SAFE_INTEGER.MAX_SAFE_INTEGER`)

Example application:
```rust
use nodejs_semver::{Range, Version};

fn main() {
    let range = "<=11";
    let version = "11.0.0";
    let req: Range = range.parse().expect(&format!("err: {}", range));
    let version: Version = version.parse().expect(&format!("err: {}", version));
    println!("result: {}", version.satisfies(&req));
    println!("result: {}", req.satisfies(&version));
}
```

running the above example without this patch:
```
result: false
result: false
```

running the above example with this patch:
```
result: true
result: true
```